### PR TITLE
trying render google btn

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "classnames": "^2.3.1",
     "emoji-short-name": "^2.0.0",
     "express": "~4.18.1",
+    "gapi-script": "^1.2.0",
     "i18next": "^21.8.14",
     "inferno": "^7.4.11",
     "inferno-create-element": "^7.4.11",

--- a/src/shared/components/home/signup.tsx
+++ b/src/shared/components/home/signup.tsx
@@ -1,5 +1,6 @@
 import { None, Option, Some } from "@sniptt/monads";
 import { Options, passwordStrength } from "check-password-strength";
+import { gapi } from "gapi-script";
 import { I18nKeys } from "i18next";
 import { Component, linkEvent } from "inferno";
 import { T } from "inferno-i18next-dess";
@@ -358,6 +359,7 @@ export class Signup extends Component<any, State> {
             value={toUndefined(this.state.registerForm.honeypot)}
             onInput={linkEvent(this, this.handleHoneyPotChange)}
           />
+
           <div class="form-group row">
             <div class="col-sm-10">
               <button type="submit" class="btn btn-secondary">
@@ -369,9 +371,30 @@ export class Signup extends Component<any, State> {
               </button>
             </div>
           </div>
+
+          <div id="my-signin2">{this.registerGoogle()}</div>
         </form>
       ),
       none: <></>,
+    });
+  }
+
+  registerGoogle() {
+    function onSuccess(googleUser) {
+      console.log("Logged in as: " + googleUser.getBasicProfile().getName());
+    }
+    function onFailure(error) {
+      console.log(error);
+    }
+
+    return gapi.signin2.render("my-signin2", {
+      scope: "profile email",
+      width: 240,
+      height: 50,
+      longtitle: true,
+      theme: "dark",
+      onsuccess: onSuccess,
+      onfailure: onFailure,
     });
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3873,6 +3873,11 @@ fuse.js@^6.5.3:
   resolved "https://registry.yarnpkg.com/fuse.js/-/fuse.js-6.5.3.tgz#7446c0acbc4ab0ab36fa602e97499bdb69452b93"
   integrity sha512-sA5etGE7yD/pOqivZRBvUBd/NaL2sjAu6QuSaFoe1H2BrJSkH/T/UXAJ8CdXdw7DvY3Hs8CXKYkDWX7RiP5KOg==
 
+gapi-script@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/gapi-script/-/gapi-script-1.2.0.tgz#8106ad0abb36661ce4fab62ef6efada288d7169e"
+  integrity sha512-NKTVKiIwFdkO1j1EzcrWu/Pz7gsl1GmBmgh+qhuV2Ytls04W/Eg5aiBL91SCiBM9lU0PMu7p1hTVxhh1rPT5Lw==
+
 gauge@~2.7.3:
   version "2.7.4"
   resolved "https://registry.yarnpkg.com/gauge/-/gauge-2.7.4.tgz#2c03405c7538c39d7eb37b317022e325fb018bf7"


### PR DESCRIPTION
traceback:

`import { gapi, gapiComplete } from './gapiScript';
^^^^^^

SyntaxError: Cannot use import statement outside a module
    at Object.compileFunction (node:vm:360:18)
    at wrapSafe (node:internal/modules/cjs/loader:1048:15)
    at Module._compile (node:internal/modules/cjs/loader:1083:27)
    at Module._extensions..js (node:internal/modules/cjs/loader:1173:10)
    at Module.load (node:internal/modules/cjs/loader:997:32)
    at Module._load (node:internal/modules/cjs/loader:838:12)
    at Module.require (node:internal/modules/cjs/loader:1021:19)
    at require (node:internal/modules/cjs/helpers:103:18)
    at gapi-script (/Users/michailspiridonov/PycharmProjects/lemmy/lemmy-ui/dist/js/server.js:1207:18)
    at __webpack_require__ (/Users/michailspiridonov/PycharmProjects/lemmy/lemmy-ui/dist/js/server.js:1491:41)

Node.js v18.8.0`